### PR TITLE
fix(upstream): Add ckeditor codemirror v1.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,21 @@
             "url": "https://packages.drupal.org/8"
         },
         {
-          "type": "vcs",
-          "url": "http://github.com/heshanlk/webform_migrate.git"
+            "type"    : "package",
+            "package" : {
+                "name"    : "w8tcha/ckeditor-codemirror",
+                "version" : "v1.16",
+                "type"    : "drupal-library",
+                "dist"    : {
+                    "url"  : "https://github.com/w8tcha/CKEditor-CodeMirror-Plugin/archive/1.16.tar.gz",
+                    "type" : "tar"
+                },
+                "source"  : {
+                    "url"       : "https://github.com/w8tcha/CKEditor-CodeMirror-Plugin.git",
+                    "type"      : "git",
+                    "reference" : "1.16"
+                }
+            }
         },
         {
             "type"    : "package",

--- a/docker/composer.json
+++ b/docker/composer.json
@@ -39,8 +39,21 @@
             "url": "https://packages.drupal.org/8"
         },
         {
-          "type": "vcs",
-          "url": "http://github.com/heshanlk/webform_migrate.git"
+            "type"    : "package",
+            "package" : {
+                "name"    : "w8tcha/ckeditor-codemirror",
+                "version" : "v1.16",
+                "type"    : "drupal-library",
+                "dist"    : {
+                    "url"  : "https://github.com/w8tcha/CKEditor-CodeMirror-Plugin/archive/1.16.tar.gz",
+                    "type" : "tar"
+                },
+                "source"  : {
+                    "url"       : "https://github.com/w8tcha/CKEditor-CodeMirror-Plugin.git",
+                    "type"      : "git",
+                    "reference" : "1.16"
+                }
+            }
         },
         {
             "type"    : "package",

--- a/docker/images/1.0-alpha1/composer.json
+++ b/docker/images/1.0-alpha1/composer.json
@@ -39,8 +39,21 @@
             "url": "https://packages.drupal.org/8"
         },
         {
-          "type": "vcs",
-          "url": "http://github.com/heshanlk/webform_migrate.git"
+            "type"    : "package",
+            "package" : {
+                "name"    : "w8tcha/ckeditor-codemirror",
+                "version" : "v1.16",
+                "type"    : "drupal-library",
+                "dist"    : {
+                    "url"  : "https://github.com/w8tcha/CKEditor-CodeMirror-Plugin/archive/1.16.tar.gz",
+                    "type" : "tar"
+                },
+                "source"  : {
+                    "url"       : "https://github.com/w8tcha/CKEditor-CodeMirror-Plugin.git",
+                    "type"      : "git",
+                    "reference" : "1.16"
+                }
+            }
         },
         {
             "type"    : "package",


### PR DESCRIPTION
[ci skip]

Additionally webform_migrate is now hosted on D.O so can remove github ref