### PR TITLE
feat(healthcheck): Add php-fpm healthcheck

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,13 @@
 # https://github.com/docker-library/drupal/blob/master/8.7/fpm-alpine/Dockerfile
 FROM drupal:8.7-fpm-alpine
 
+RUN apk --update add fcgi \
+    && wget -O /usr/local/bin/php-fpm-healthcheck https://raw.githubusercontent.com/renatomefi/php-fpm-healthcheck/master/php-fpm-healthcheck \
+    && chmod +x /usr/local/bin/php-fpm-healthcheck
+COPY docker/conf/php-fpm/status.conf /usr/local/etc/php-fpm.d/
+
+HEALTHCHECK --interval=5s --timeout=10s --start-period=5s --retries=3 CMD [ "php-fpm-healthcheck" ]
+
 # Install additional extensions
 RUN apk --update add --no-cache bash=5.0.0-r0 \
                                 git=2.22.0-r0 \

--- a/docker/conf/php-fpm/status.conf
+++ b/docker/conf/php-fpm/status.conf
@@ -1,0 +1,2 @@
+[www]
+pm.status_path = /status


### PR DESCRIPTION
Adds support for health checking with Docker + Kubernetes.


Example of Docker tracking the health:

```
❯ docker ps
CONTAINER ID        IMAGE                          COMMAND                  CREATED             STATUS                    PORTS               NAMES
2ad46613e404        drupalwxt/site-wxt:3.0.0-rc3   "docker-php-entrypoi…"   6 seconds ago       Up 5 seconds              9000/tcp            drupal-old
c65611877747        drupalwxt/site-wxt             "docker-php-entrypoi…"   44 seconds ago      Up 43 seconds (healthy)   9000/tcp            drupal
```