### PR TITLE
Updated version of `mysql-client` dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ HEALTHCHECK --interval=5s --timeout=10s --start-period=5s --retries=3 CMD [ "php
 RUN apk --update add --no-cache bash=5.0.0-r0 \
                                 git=2.22.0-r0 \
                                 gzip=1.10-r0 \
-                                mysql-client=10.3.18-r0 \
+                                mysql-client=10.3.20-r0 \
                                 patch=2.7.6-r6 \
                                 postgresql-client=11.6-r0 \
                                 ssmtp=2.64-r14 \


### PR DESCRIPTION
Previous version was causing Docker build to break.

Error from console:

```
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  mysql-client-10.3.20-r0:
    breaks: world[mysql-client=10.3.18-r0]
```