### PR TITLE
Remove patches-ignore for lightning patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,24 +91,7 @@
             "drupal/core": "-p2"
         },
         "patches": { },
-        "patches-ignore": {
-            "acquia/lightning": {
-                "drupal/core": {
-                    "1356276 - Allow profiles to define a base/parent profile and load them in the correct order":
-                    "https://www.drupal.org/files/issues/2020-03-24/1356276-531-9.0.x-9.patch",
-                    "2914389 - Allow profiles to exclude dependencies of their parent":
-                    "https://www.drupal.org/files/issues/2018-07-09/2914389-8-do-not-test.patch"
-                }
-            },
-            "drupal/lightning_core": {
-                "drupal/core": {
-                    "1356276 - Allow profiles to define a base/parent profile and load them in the correct order":
-                    "https://www.drupal.org/files/issues/2020-03-24/1356276-531-9.0.x-9.patch",
-                    "2914389 - Allow profiles to exclude dependencies of their parent":
-                    "https://www.drupal.org/files/issues/2018-07-09/2914389-8-do-not-test.patch"
-                }
-            }
-        }
+        "patches-ignore": { }
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Now that lightning has been removed we should remove the patches-ignore that reference them.