### PR TITLE
Pin docker-scaffold version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,6 @@ PLATFORM := $(shell uname -s)
 $(eval GIT_USERNAME := $(if $(GIT_USERNAME),$(GIT_USERNAME),gitlab-ci-token))
 $(eval GIT_PASSWORD := $(if $(GIT_PASSWORD),$(GIT_PASSWORD),$(CI_JOB_TOKEN)))
 DOCKER_REPO := https://github.com/drupalwxt/docker-scaffold.git
-GET_DOCKER := $(shell [ -d docker ] || git clone $(DOCKER_REPO) docker)
+SCAFFOLD_VERSION := '10.1.x'
+GET_DOCKER := $(shell [ -d docker ] || git clone --branch $(SCAFFOLD_VERSION) $(DOCKER_REPO) docker)
 include docker/Makefile


### PR DESCRIPTION
On a few projects I have ran into an issue where the version of the [drupalwxt/docker-scaffold](https://github.com/drupalwxt/docker-scaffold) being used was automatically updated to newer versions without being specified. This is becasue the Makefile just clones the docker-scaffold repo and uses the default branch. This can cause build to break due to unexpected changes.

This PR pins the branch for docker-scaffold so it doesn't automatically jump versions.